### PR TITLE
Fixed english padding for xl screens

### DIFF
--- a/src/app/components/ContactMe.tsx
+++ b/src/app/components/ContactMe.tsx
@@ -16,7 +16,7 @@ export default function ContactMe() {
       currentLanguage === "pt" ||
       currentLanguage === "pt-br"
       ? "lg:text-xl xl:text-base 2xl:text-lg"
-      : "lg:text-xl xl:text-lg 2xl:text-xl";
+      : "lg:text-xl xl:text-base 2xl:text-xl";
   };
 
   return (
@@ -59,7 +59,7 @@ export default function ContactMe() {
               />
             </Link>
           </div>
-          <div className="group">
+          {/*<div className="group">
             <Link
               href="https://www.youtube.com/@davitothestars"
               target="_blank"
@@ -71,7 +71,7 @@ export default function ContactMe() {
                 className="text-[#f78f2e] group-hover:text-[#CD201F] transition duration-160 dark:text-white"
               />
             </Link>
-          </div>
+          </div>*/}
           <div className="group">
             <Link href="mailto:daviz.contactme@gmail.com">
               <span className="sr-only">{t("ContactMe")}</span>

--- a/src/app/components/Current.tsx
+++ b/src/app/components/Current.tsx
@@ -95,8 +95,9 @@ export default function Current() {
       </div>
 
       <div
-        className="relative z-10 text-xl my-3
-      xl:my-6 2xl:my-8"
+        className={`relative z-10 text-xl my-3
+      xl:my-6 2xl:my-8
+      ${getTextSizeCurrentRole()}`}
       >
         {t("CurrentRole")}
       </div>


### PR DESCRIPTION
- Fixed english padding for xl screens 
- For the English (default) home page, the ContactMe and Footer were occupying too much space for xl screens (e.g. Macbook) in the vertical-axis. This was resolved by decreasing the text size and padding. 

- Before (view the footer on the bottom right): 
<img width="1332" alt="Screenshot 2025-02-23 at 12 42 14 AM" src="https://github.com/user-attachments/assets/66ae66f0-aebf-41ba-a878-99ba455f996a" />

- After: 
<img width="1306" alt="Screenshot 2025-02-23 at 12 52 01 AM" src="https://github.com/user-attachments/assets/4f8002de-4c02-435a-8c86-4b5638a0bcb2" />
